### PR TITLE
Fix/trixie/unload_camera

### DIFF
--- a/src/appcontroller.cpp
+++ b/src/appcontroller.cpp
@@ -61,10 +61,10 @@ void AppController::showWindow()
 
 void AppController::loadCamera() {
     QObject *rootObject = m_engine->rootObjects().first();
-    QObject *camera = rootObject->findChild<QObject*>("camera");
+    QObject *camera = rootObject->findChild<QObject*>("cameraLoader");
 
     if (camera) {
-        camera->setProperty("cameraState", QCamera::ActiveState);
+        camera->setProperty("active", true);
         qDebug() << "Camera state set to Active";
     }
 }

--- a/src/qml/Camera.qml
+++ b/src/qml/Camera.qml
@@ -57,13 +57,15 @@ Item {
             }
         }
 
-        if (camera.aspWide) {
+        if (camera.aspWide && camera.firstSixteenNineResolution != undefined) {
             camera.imageCapture.resolution = camera.firstSixteenNineResolution;
         } else {
-            camera.imageCapture.resolution = camera.firstFourThreeResolution
+            if (camera.firstFourThreeResolution != undefined) {
+                camera.imageCapture.resolution = camera.firstFourThreeResolution
+            }
         }
 
-        if (settings.cameras[camera.deviceId] && settings.cameras[camera.deviceId].resolution !== undefined) {
+        if (settings.cameras[camera.deviceId] && settings.cameras[camera.deviceId].resolution !== undefined && camera.imageCapture.supportedResolutions[0] != undefined) {
             settings.cameras[camera.deviceId].resolution = Math.round(
                 (camera.imageCapture.supportedResolutions[0].width * camera.imageCapture.supportedResolutions[0].height) / 1000000
             );
@@ -81,10 +83,6 @@ Item {
 
     function handleCameraTakeVideo() {
         handleVideoRecording()
-    }
-
-    function handleCameraEnableGestures(values) {
-
     }
 
     function handleCameraChangeResolution(resolution) {

--- a/src/qml/Camera.qml
+++ b/src/qml/Camera.qml
@@ -117,6 +117,10 @@ Item {
         camera.aspWide = aspWide;
     }
 
+    function handleSetDeviceID(deviceIdToSet) {
+        camera.deviceId = deviceIdToSet
+    }
+
     Camera {
         id: camera
         objectName: "camera"

--- a/src/qml/Camera.qml
+++ b/src/qml/Camera.qml
@@ -69,13 +69,11 @@ Item {
     }
 
     function handleCameraTakeShot() {
-        console.log("Signal to take pciture.");
         pinchArea.enabled = true
         camera.imageCapture.capture()
     }
 
     function handleCameraTakeVideo() {
-        console.log("Signal to take pciture.");
         handleVideoRecording()
     }
 
@@ -85,19 +83,18 @@ Item {
 
     function handleCameraChangeResolution(resolution) {
         if (resolution == "4:3") {
-            console.log("changing to 4:3")
-            console.log(camera.firstFourThreeResolution)
             camera.imageCapture.resolution = camera.firstFourThreeResolution
         }
         else if (resolution == "16:9") {
-            console.log("changing to 16:9")
             camera.imageCapture.resolution = camera.firstSixteenNineResolution
-            console.log(camera.firstSixteenNineResolution)
         }
     }
 
     function handleStopCamera() {
-        camera.stop();
+        if (camera !== null && camera !== undefined) {
+            camera.stop();
+            cameraLoader.active = false;
+        }
     }
 
     function handleStartCamera() {
@@ -163,10 +160,6 @@ Item {
                 if (window.locationAvailable === 1 ) {
                     fileManager.appendGPSMetadata(path);
                 }
-            }
-
-            onResolutionChanged: {
-                console.log("Resolution changed to: " + camera.imageCapture.resolution);
             }
         }
 

--- a/src/qml/Camera.qml
+++ b/src/qml/Camera.qml
@@ -121,6 +121,41 @@ Item {
         camera.deviceId = deviceIdToSet
     }
 
+    function initializeCameraList() {
+        var blacklist = []
+
+        if (settingsCommon.blacklist !== "") {
+            blacklist = settingsCommon.blacklist.split(',');
+        }
+
+        allCamerasModel.clear();
+
+        for (var i = 0; i < QtMultimedia.availableCameras.length; i++) {
+            var cameraInfo = QtMultimedia.availableCameras[i];
+            var isBlacklisted = false;
+
+            for (var p in blacklist) {
+                if (blacklist[p] == cameraInfo.deviceId) {
+                    console.log("Camera with the id:", blacklist[p], "is blacklisted, not adding to camera list!");
+                    isBlacklisted = true;
+                    break;
+                }
+            }
+
+            if (isBlacklisted) {
+                continue;
+            }
+
+            if (cameraInfo.position === Camera.BackFace) {
+                allCamerasModel.append({"cameraId": cameraInfo.deviceId, "index": i, "position": cameraInfo.position});
+                window.backCameras += 1;
+            } else if (cameraInfo.position === Camera.FrontFace) {
+                allCamerasModel.insert(0, {"cameraId": cameraInfo.deviceId, "index": i, "position": cameraInfo.position});
+                window.frontCameras += 1;
+            }
+        }
+    }
+
     Camera {
         id: camera
         objectName: "camera"

--- a/src/qml/Camera.qml
+++ b/src/qml/Camera.qml
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2024 Furi Labs
+//
+// Authors:
+// Joaquin Philco <joaquinphilco@gmail.com>
+
 import QtQuick 2.0
 import QtQuick 2.15
 import QtQuick.Controls 2.15

--- a/src/qml/Camera.qml
+++ b/src/qml/Camera.qml
@@ -101,6 +101,10 @@ Item {
         camera.stop();
     }
 
+    function handleStartCamera() {
+        camera.start();
+    }
+
     Camera {
         id: camera
         objectName: "camera"
@@ -167,8 +171,6 @@ Item {
 
             camera.deviceId = currentCam
             camera.start()
-
-            // store properties into settings
 
             settings.cameraPosition = camera.position
         }

--- a/src/qml/Camera.qml
+++ b/src/qml/Camera.qml
@@ -124,7 +124,7 @@ Item {
 
         position: settings.cameraPosition
 
-        deviceId: settings.cameraDeviceId
+        deviceId: window.cameraDeviceId
 
         focus {
             focusMode: settings.focusMode

--- a/src/qml/Camera.qml
+++ b/src/qml/Camera.qml
@@ -105,6 +105,14 @@ Item {
         camera.start();
     }
 
+    function handleSetFocusMode(focusMode) {
+        camera.focus.focusMode = focusMode;
+    }
+
+    function handleSetFocusPointMode(focusPointMode) {
+        camera.focus.focusPointMode = focusPointMode;
+    }
+
     Camera {
         id: camera
         objectName: "camera"
@@ -179,8 +187,7 @@ Item {
             if (camera.cameraStatus == Camera.LoadedStatus) {
                 cameraItem.fnAspectRatio()
             } else if (camera.cameraStatus == Camera.ActiveStatus) {
-                camera.focus.focusMode = Camera.FocusContinuous
-                camera.focus.focusPointMode = Camera.FocusPointAuto
+                focusState.state = "AutomaticFocus";
             }
         }
 
@@ -192,9 +199,6 @@ Item {
             settings.setValue("aspWide", aspWide);
         }
     }
-
-
-
 
     VideoOutput {
         id: viewfinder
@@ -293,7 +297,7 @@ Item {
                                 focusState.state = "TargetLocked"
                                 aefLockTimer.stop()
                             } else {
-                                focusState.state = "ManualFocus"
+                                focusState.state = "AutomaticFocus"
                                 window.aeflock = "AEFLockOff"
                             }
 
@@ -306,9 +310,6 @@ Item {
                                 focusPointRect.y = mouse.y - (focusPointRect.height / 2)
                             }
 
-                            console.log("index: " + configBar.currIndex)
-                            console.log("Flash Mode: " + camera.flash.mode)
-                            console.log("Camera Position: " + camera.position)
                             window.blurView = 0
                             configBarDrawer.close()
                             optionContainer.state = "closed"

--- a/src/qml/Camera.qml
+++ b/src/qml/Camera.qml
@@ -89,12 +89,11 @@ Item {
             console.log(camera.firstFourThreeResolution)
             camera.imageCapture.resolution = camera.firstFourThreeResolution
         }
-        else if (resolution == "16:9" ) {
+        else if (resolution == "16:9") {
             console.log("changing to 16:9")
             camera.imageCapture.resolution = camera.firstSixteenNineResolution
             console.log(camera.firstSixteenNineResolution)
         }
-
     }
 
     function handleStopCamera() {
@@ -113,6 +112,10 @@ Item {
         camera.focus.focusPointMode = focusPointMode;
     }
 
+    function handleSetCameraAspWide(aspWide) {
+        camera.aspWide = aspWide;
+    }
+
     Camera {
         id: camera
         objectName: "camera"
@@ -120,7 +123,7 @@ Item {
 
         property variant firstFourThreeResolution
         property variant firstSixteenNineResolution
-        property var aspWide: settings.settingsAspWide
+        property var aspWide: 0
 
         position: settings.cameraPosition
 
@@ -160,6 +163,10 @@ Item {
                 if (window.locationAvailable === 1 ) {
                     fileManager.appendGPSMetadata(path);
                 }
+            }
+
+            onResolutionChanged: {
+                console.log("Resolution changed to: " + camera.imageCapture.resolution);
             }
         }
 

--- a/src/qml/MediaReview.qml
+++ b/src/qml/MediaReview.qml
@@ -245,8 +245,8 @@ Rectangle {
                 }
             }
 
-            function scanImage() {
-                var result = QRCodeHandler.checkQRCodeInMedia(currentFileUrl, image.width, image.height)
+            function scanImageURL() {
+                var result = QRCodeHandler.scanImageURL(currentFileUrl, image.width, image.height)
 
                 if (result.isValid) {
                     imageContainer.positionData = getScaledCorners(result.position, result.readWidth, result.readHeight, image.width, image.height)
@@ -261,6 +261,31 @@ Rectangle {
                 } else {
                     qrCodeComponent.lastValidResult = null
                 }
+            }
+
+            function scanImage() {
+                image.grabToImage(function(result) {
+                    if (result.image) {
+                        var qrCodeResult = QRCodeHandler.scanImage(result.image);
+
+                        if (qrCodeResult.isValid) {
+                            imageContainer.positionData = getScaledCorners(qrCodeResult.position, qrCodeResult.readWidth, qrCodeResult.readHeight, image.width, image.height)
+
+                            qrCodeComponent.smoothedPosition = imageContainer.positionData
+
+                            qrCodeComponent.updateLowPass(imageContainer.positionData);
+
+                            qrCodeComponent.updateOBBFromImage(imageContainer.positionData, image.scale, image.x, image.y);
+
+                            qrCodeComponent.lastValidResult = qrCodeResult
+                        } else {
+                            qrCodeComponent.lastValidResult = null
+                        }
+                    } else {
+                        console.error("Failed to grab image for QR scanning.");
+                        qrCodeComponent.lastValidResult = null;
+                    }
+                });
             }
 
             PinchArea {
@@ -294,7 +319,7 @@ Rectangle {
                     }
 
                     onPressAndHold: {
-                        scanImage()
+                        scanImageURL()
                     }
 
                     onReleased: {
@@ -329,7 +354,7 @@ Rectangle {
                 repeat: false
                 onTriggered: {
                     if (mediaDate.visible){
-                        scanImage()
+                        scanImageURL()
                     }
                 }
             }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -70,18 +70,13 @@ ApplicationWindow {
     signal setCameraAspWide(int aspWide)
 
     onActiveChanged:{
-        // if (camera.cameraState === Camera.UnloadedState && window.active) {
-        //     console.log("restarting camera")
-        //     //camera.cameraState = Camera.ActiveState
-        //    // camera.start()
-        // }
+        cameraLoader.active = true
     }
 
     onClosing: {
-        console.log("Window closing event triggered")
         close.accepted = false
         console.log("Stopping camera...")
-        // camera.stop()
+        window.stopCamera();
         customClosing()
     }
 
@@ -246,7 +241,7 @@ ApplicationWindow {
         source: "Camera.qml"
 
         onLoaded: {
-            console.log("Camera component has been loaded!")
+            console.log("Camera component loaded")
             window.cameraTakeShot.connect(cameraLoader.item.handleCameraTakeShot);
             window.cameraTakeVideo.connect(cameraLoader.item.handleCameraTakeVideo);
             window.cameraChangeResolution.connect(cameraLoader.item.handleCameraChangeResolution);
@@ -375,7 +370,6 @@ ApplicationWindow {
 
                         onClicked: {
                             window.blurView = 0
-                            //camera.deviceId = model.cameraId
                             window.cameraDeviceId = model.cameraId
                             optionContainer.state = "closed"
                         }
@@ -532,9 +526,7 @@ ApplicationWindow {
                     }
 
                     onClicked: {
-                        console.log("flash button");
                         if (settings.cameraPosition !== Camera.FrontFace) {
-                            console.log("enabled")
                             switch(settings.flashMode) {
                                 case Camera.FlashOff:
                                     settings.flashMode = Camera.FlashOn;
@@ -1618,16 +1610,6 @@ ApplicationWindow {
 
         onClicked: {
             configBarDrawer.open()
-        }
-    }
-
-    Button {
-        text: cameraLoader.active ? "Unload Camera" : "Load Camera"
-        anchors.centerIn: parent
-        onClicked: {
-            window.stopCamera()
-
-            cameraLoader.active = !cameraLoader.active
         }
     }
 }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -60,7 +60,6 @@ ApplicationWindow {
     signal customClosing()
     signal cameraTakeShot()
     signal cameraTakeVideo()
-    signal cameraEnableGestures(bool value)
     signal cameraChangeResolution(string resolution)
     signal stopCamera()
     signal startCamera()

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -63,6 +63,7 @@ ApplicationWindow {
     signal cameraEnableGestures(bool value)
     signal cameraChangeResolution(string resolution)
     signal stopCamera()
+    signal startCamera()
     signal setFlashState(int flashState)
 
     onActiveChanged:{
@@ -256,6 +257,7 @@ ApplicationWindow {
             window.cameraChangeResolution.connect(cameraLoader.item.handleCameraChangeResolution);
             window.stopCamera.connect(cameraLoader.item.handleStopCamera);
             window.setFlashState.connect(cameraLoader.item.handleSetFlashState);
+            window.startCamera.connect(cameraLoader.item.handleStartCamera);
         }
     }
 
@@ -1093,7 +1095,7 @@ ApplicationWindow {
     MediaReview {
         id: mediaView
         anchors.fill: parent
-        //onClosed: camera.start()
+        onClosed: window.startCamera()
         focus: visible
 
         scalingRatio: window.scalingRatio

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -70,7 +70,12 @@ ApplicationWindow {
     signal setCameraAspWide(int aspWide)
 
     onActiveChanged:{
-        cameraLoader.active = true
+        if (!window.active) {
+            cameraLoader.active = false;
+            console.log("Stopping camera...")
+        } else {
+            cameraLoader.active = true;
+        }
     }
 
     onClosing: {

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -781,7 +781,6 @@ ApplicationWindow {
                         anchors.fill: parent
                         onClicked: {
                             mediaView.visible = true;
-                            window.stopCamera();
                         }
                     }
                 }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -50,7 +50,6 @@ ApplicationWindow {
     property var popupButtons: null
     property var mediaViewOpened: false
     property var focusPointVisible: false
-    property var cameraAspWide: 1
     property var aeflock: "AEFLockOff"
     property var pinchAreaEnabled: true
 
@@ -68,6 +67,7 @@ ApplicationWindow {
     signal setFlashState(int flashState)
     signal setFocusMode(int focusMode)
     signal setFocusPointMode(int focusPointMode)
+    signal setCameraAspWide(int aspWide)
 
     onActiveChanged:{
         // if (camera.cameraState === Camera.UnloadedState && window.active) {
@@ -151,10 +151,10 @@ ApplicationWindow {
         property var hideInfoDrawer: 0
         property int gpsOn: 0
         property int cameraPosition: Camera.FrontFace
-        property int settingsAspWide: 0
 
         onFocusModeChanged: setFocusMode(settings.focusMode)
         onFocusPointModeChanged: setFocusPointMode(settings.focusPointMode)
+        onAspWideChanged: setCameraAspWide(settings.aspWide)
     }
 
     Settings {
@@ -255,6 +255,7 @@ ApplicationWindow {
             window.startCamera.connect(cameraLoader.item.handleStartCamera);
             window.setFocusPointMode.connect(cameraLoader.item.handleSetFocusPointMode);
             window.setFocusMode.connect(cameraLoader.item.handleSetFocusMode);
+            window.setCameraAspWide.connect(cameraLoader.item.handleSetCameraAspWide);
         }
     }
 
@@ -262,12 +263,6 @@ ApplicationWindow {
         id: sound
         source: "sounds/camera-shutter.wav"
     }
-
-    // Rectangle {
-    //     id: videoFrame
-    //     anchors.fill: parent
-    //     color: "black"
-    // }
 
     Timer {
         id: swappingDelay
@@ -1518,8 +1513,7 @@ ApplicationWindow {
                             font.pixelSize:  35 * window.scalingRatio * 0.5
                             font.bold: true
                             font.family: "Lato Hairline"
-                            palette.buttonText: settings.settingsAspWide === 1 ? "white" : "gray"
-                            //palette.buttonText: window.cameraAspWide === 1 ? "white" : "gray"
+                            palette.buttonText: settings.aspWide === 1 ? "white" : "gray"
 
                             background: Rectangle {
                                 width: 60 * window.scalingRatio
@@ -1532,10 +1526,9 @@ ApplicationWindow {
                             }
 
                             onClicked: {
-                                // camera.aspWide = 1;
-                                settings.settingsAspWide = 1;
+                                settings.aspWide = 1;
                                 configBar.aspectRatioOpened = 0;
-                                window.cameraChangeResolution(fourThreeButton.text)
+                                window.cameraChangeResolution(sixteenNineButton.text)
                             }
                         }
 
@@ -1546,7 +1539,7 @@ ApplicationWindow {
                             font.pixelSize:  35 * window.scalingRatio * 0.5
                             font.bold: true
                             font.family: "Lato Hairline"
-                            palette.buttonText: settings.settingsAspWide === 1 ? "gray" : "white"
+                            palette.buttonText: settings.aspWide === 1 ? "gray" : "white"
 
                             background: Rectangle {
                                 width: 60 * window.scalingRatio
@@ -1559,8 +1552,7 @@ ApplicationWindow {
                             }
 
                             onClicked: {
-                                //camera.aspWide = 0;
-                                settings.settingsAspWide = 0;
+                                settings.aspWide = 0;
                                 configBar.aspectRatioOpened = 0;
                                 window.cameraChangeResolution(fourThreeButton.text)
                             }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -65,6 +65,8 @@ ApplicationWindow {
     signal stopCamera()
     signal startCamera()
     signal setFlashState(int flashState)
+    signal setFocusMode(int focusMode)
+    signal setFocusPointMode(int focusPointMode)
 
     onActiveChanged:{
         // if (camera.cameraState === Camera.UnloadedState && window.active) {
@@ -133,7 +135,7 @@ ApplicationWindow {
         property int aspWide: 0
         property int flashMode: Camera.FlashOff
         property int focusMode: Camera.FocusAuto
-        property int focusPointMode: Camera.FocusPointCenter
+        property int focusPointMode: Camera.FocusPointCustom
         property var cameras: [{"cameraId": 0, "resolution": 0},
                                 {"cameraId": 1, "resolution": 0},
                                 {"cameraId": 2, "resolution": 0},
@@ -144,13 +146,15 @@ ApplicationWindow {
                                 {"cameraId": 7, "resolution": 0},
                                 {"cameraId": 8, "resolution": 0},
                                 {"cameraId": 9, "resolution": 0}]
-
         property int soundOn: 1
         property var hideInfoDrawer: 0
         property int gpsOn: 0
         property int cameraPosition: Camera.FrontFace
         property int settingsAspWide: 0
         property var cameraDeviceId: model.cameraId;
+
+        onFocusModeChanged: setFocusMode(settings.focusMode)
+        onFocusPointModeChanged: setFocusPointMode(settings.focusPointMode)
     }
 
     Settings {
@@ -175,7 +179,7 @@ ApplicationWindow {
 
                 PropertyChanges {
                     target: settings
-                    focusMode: Camera.FocusAuto
+                    focusMode: Camera.FocusContinuous
                     focusPointMode: Camera.FocusPointCustom
                 }
             },
@@ -190,15 +194,6 @@ ApplicationWindow {
             },
             State {
                 name: "AutomaticFocus" // Moving around and no touch, no AEF lock.
-
-                PropertyChanges {
-                    target: settings
-                    focusMode: Camera.FocusAuto
-                    focusPointMode: Camera.FocusPointAuto
-                }
-            },
-            State {
-                name: "ManualFocus" // Touch screen and no AEF lock.
 
                 PropertyChanges {
                     target: settings
@@ -258,6 +253,8 @@ ApplicationWindow {
             window.stopCamera.connect(cameraLoader.item.handleStopCamera);
             window.setFlashState.connect(cameraLoader.item.handleSetFlashState);
             window.startCamera.connect(cameraLoader.item.handleStartCamera);
+            window.setFocusPointMode.connect(cameraLoader.item.handleSetFocusPointMode);
+            window.setFocusMode.connect(cameraLoader.item.handleSetFocusMode);
         }
     }
 
@@ -303,8 +300,10 @@ ApplicationWindow {
         repeat: false
 
         onTriggered: {
-            focusState.state = "AutomaticFocus"
-            window.aeflock = "AEFLockOff"
+            if (focusState.state !== "TargetLocked") {
+                focusState.state = "AutomaticFocus"
+                window.aeflock = "AEFLockOff"
+            }
         }
     }
 

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -67,6 +67,7 @@ ApplicationWindow {
     signal setFocusMode(int focusMode)
     signal setFocusPointMode(int focusPointMode)
     signal setCameraAspWide(int aspWide)
+    signal setDeviceID(int deviceIdToSet)
 
     onActiveChanged:{
         if (!window.active) {
@@ -255,6 +256,7 @@ ApplicationWindow {
             window.setFocusPointMode.connect(cameraLoader.item.handleSetFocusPointMode);
             window.setFocusMode.connect(cameraLoader.item.handleSetFocusMode);
             window.setCameraAspWide.connect(cameraLoader.item.handleSetCameraAspWide);
+            window.setDeviceID.connect(cameraLoader.item.handleSetDeviceID);
         }
     }
 
@@ -353,8 +355,8 @@ ApplicationWindow {
                     Layout.alignment: Qt.AlignHCenter
                     Layout.preferredWidth: parent.width * 0.9
                     Button {
-                        property var pos: model.position == 1 ? "Back" : "Front"
-                        property var numDigits: settings.cameras[model.cameraId].resolution.toString().length
+                        property var pos: model.position == 1 ? "Back" : "Front";
+                        property var numDigits: settings.cameras[model.cameraId].resolution.toString().length;
                         Layout.alignment: Qt.AlignLeft
                         visible: parent.visible
                         icon.source: "icons/cameraVideoSymbolic.svg"
@@ -374,6 +376,7 @@ ApplicationWindow {
 
                         onClicked: {
                             window.blurView = 0
+                            setDeviceID(model.cameraId)
                             window.cameraDeviceId = model.cameraId
                             optionContainer.state = "closed"
                         }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -95,38 +95,6 @@ ApplicationWindow {
 
     ListModel {
         id: allCamerasModel
-        Component.onCompleted: {
-            var blacklist
-
-            if (settingsCommon.blacklist != "") {
-                blacklist = settingsCommon.blacklist.split(',')
-            }
-
-            for (var i = 0; i < QtMultimedia.availableCameras.length; i++) {
-                var cameraInfo = QtMultimedia.availableCameras[i];
-                var isBlacklisted = false;
-
-                for (var p in blacklist) {
-                    if (blacklist[p] == cameraInfo.deviceId) {
-                        console.log("Camera with the id:", blacklist[p], "is blacklisted, not adding to camera list!");
-                        isBlacklisted = true;
-                        break;
-                    }
-                }
-
-                if (isBlacklisted) {
-                    continue;
-                }
-
-                if (cameraInfo.position === Camera.BackFace) {
-                    append({"cameraId": cameraInfo.deviceId, "index": i, "position": cameraInfo.position});
-                    window.backCameras += 1;
-                } else if (cameraInfo.position === Camera.FrontFace) {
-                    insert(0, {"cameraId": cameraInfo.deviceId, "index": i, "position": cameraInfo.position});
-                    window.frontCameras += 1;
-                }
-            }
-        }
     }
 
     Settings {
@@ -257,6 +225,8 @@ ApplicationWindow {
             window.setFocusMode.connect(cameraLoader.item.handleSetFocusMode);
             window.setCameraAspWide.connect(cameraLoader.item.handleSetCameraAspWide);
             window.setDeviceID.connect(cameraLoader.item.handleSetDeviceID);
+
+            cameraLoader.item.initializeCameraList(); // Initialize CameraList model once camera component loaded
         }
     }
 

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -46,6 +46,7 @@ ApplicationWindow {
     property var popupTitle: null
     property var popupBody: null
     property var popupData: null
+    property var cameraDeviceId: null
     property var popupButtons: null
     property var mediaViewOpened: false
     property var focusPointVisible: false
@@ -151,7 +152,6 @@ ApplicationWindow {
         property int gpsOn: 0
         property int cameraPosition: Camera.FrontFace
         property int settingsAspWide: 0
-        property var cameraDeviceId: model.cameraId;
 
         onFocusModeChanged: setFocusMode(settings.focusMode)
         onFocusPointModeChanged: setFocusPointMode(settings.focusPointMode)
@@ -381,7 +381,7 @@ ApplicationWindow {
                         onClicked: {
                             window.blurView = 0
                             //camera.deviceId = model.cameraId
-                            settings.cameraDeviceId = model.cameraId
+                            window.cameraDeviceId = model.cameraId
                             optionContainer.state = "closed"
                         }
                     }

--- a/src/qrcodehandler.h
+++ b/src/qrcodehandler.h
@@ -8,9 +8,14 @@
 #ifndef QRCODEHANDLER_H
 #define QRCODEHANDLER_H
 
+#include "zxingreader.h"
+
 #include <QObject>
 #include <QDBusMessage>
 #include <QVariant>
+
+using ZXing::Result;
+using ZXing::ImageFormat;
 
 #define NO_ROUTE_SIGNAL QString("icons/network-wireless-signal-no-route.svg")
 #define OFFLINE_SIGNAL QString("icons/network-wireless-signal-offline.svg")
@@ -30,7 +35,10 @@ public:
     Q_INVOKABLE QString parseQrString(const QString &qrString);
     Q_INVOKABLE void openUrlInFirefox(const QString &url);
     Q_INVOKABLE void connectToWifi();
-    Q_INVOKABLE QVariant checkQRCodeInMedia(const QString &currUrl);
+    Q_INVOKABLE QVariant scanImageURL(const QString &currUrl);
+    Q_INVOKABLE QVariant scanImage(const QImage image);
+    ZXing::ImageFormat getImageFormatFromQImage(const QImage& img);
+    QVariantMap constructResultMap(const Result &result, const QImage &image, QVariantMap resultMap);
     bool forgetConnection();
     bool deactivateConnection();
     quint8 getSignalStrength(const QString &ap);


### PR DESCRIPTION
Properly unloading camera resoruces and quality improvements on AEF lock and QR gallery.

--> Optimized QR code scanning in the MediaReview module by eliminating unnecessary image loading with every image scan.

--> Adjusted the QR code scanning process to reset when the media URL changes.

--> Modified the camera loading process to query the cameraLoader component instead of the camera directly.

--> Enhanced the management of the camera object, ensuring it gets destroyed when the application is inactive but not closed.

--> Implemented a mechanism to unload camera loader resources when the application is closed.

--> Improved the Auto Exposure Focus (AEF) lock feature by simplifying its dependency states and setting focus modes based on settings changes, with a touch-responsive focus point on the camera screen.
