### PR TITLE
Add QR code default result

### DIFF
--- a/src/qml/QrCode.qml
+++ b/src/qml/QrCode.qml
@@ -203,6 +203,16 @@ Item {
                         isPrimary: true,
                     }
                 ], wifiID)
+            } else {
+                openPopupFunction("QR Code Detected", "Content: " + lastValidResult.text, [
+                    {
+                        text: "OK",
+                        isPrimary: true,
+                    },
+                    {
+                        text: "Copy",
+                    }
+                ], lastValidResult.text)
             }
         }
 

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -424,6 +424,24 @@ ApplicationWindow {
         width: parent.width
         visible: !mediaView.visible
 
+        ToolTip {
+            id: copiedTip
+            text: "Copied to clipboard"
+            timeout: 1000
+            visible: false
+
+            background: Rectangle {
+                color: "#ff383838"
+                radius: 6 * window.scalingRatio
+            }
+
+            contentItem: Text {
+                text: copiedTip.text
+                color: "white"
+                font.pixelSize: 14 * window.scalingRatio
+            }
+        }
+
         Item {
             id: hotBar
             anchors.top: parent.top
@@ -1024,7 +1042,7 @@ ApplicationWindow {
 
         scalingRatio: window.scalingRatio
     }
-    
+
     Rectangle {
         id: popupBackdrop
         width: window.width
@@ -1208,6 +1226,7 @@ ApplicationWindow {
                                     /* oh god */
                                     copyToClipboardHelper.selectAll()
                                     copyToClipboardHelper.copy()
+                                    copiedTip.open()
                                 }
                             }
 


### PR DESCRIPTION
When QR code detects anything else but a url or wifi command, treat it as text and let the user copy it.