### PR TITLE
qml/Camera: switch video recording from MJPEG to h264

### DIFF
--- a/src/qml/Camera.qml
+++ b/src/qml/Camera.qml
@@ -423,27 +423,46 @@ Item {
         property string outputPath: StandardPaths.writableLocation(StandardPaths.MoviesLocation).toString().replace("file://","") +
                                             "/furios-camera/video" + Qt.formatDateTime(new Date(), "yyyyMMdd_hhmmsszzz") + ".mkv"
 
+        property int vidW: camera.viewfinder.resolution.width * 3 / 4
+        property int vidH: camera.viewfinder.resolution.height * 3 / 4
+        property string videoEncoder: "x264enc bitrate=8000 speed-preset=ultrafast tune=zerolatency ! video/x-h264, profile=baseline ! h264parse"
+
         property var backends: [
             {
                 front: "gst-pipeline: droidcamsrc mode=2 camera-device=1 ! video/x-raw ! videoconvert ! qtvideosink",
-                frontRecord: "gst-pipeline: droidcamsrc camera_device=1 mode=2 ! tee name=t t. ! queue ! video/x-raw, width=" + (camera.viewfinder.resolution.width * 3 / 4) + ", height=" + (camera.viewfinder.resolution.height * 3 / 4) + " ! videoconvert ! videoflip video-direction=2 ! qtvideosink t. ! queue ! video/x-raw, width=" + (camera.viewfinder.resolution.width * 3 / 4) + ", height=" + (camera.viewfinder.resolution.height * 3 / 4) + " ! videoconvert ! videoflip video-direction=auto ! jpegenc ! mkv. autoaudiosrc ! queue ! audioconvert ! droidaenc ! mkv. matroskamux name=mkv ! filesink location=" + outputPath,
+                frontRecord: "gst-pipeline: droidcamsrc mode=2 camera-device=1 ! tee name=t t. ! queue ! video/x-raw, width="
+                    + vidW
+                    + ", height="
+                    + vidH
+                    + " ! videoconvert ! videoflip video-direction=2 ! qtvideosink t. ! queue ! video/x-raw, width="
+                    + vidW
+                    + ", height="
+                    + vidH
+                    + " ! videoconvert ! videoflip video-direction=auto ! "
+                    + videoEncoder
+                    + " ! mkv. autoaudiosrc ! queue ! audioconvert ! droidaenc"
+                    + " ! mkv. matroskamux name=mkv ! filesink location="
+                    + outputPath,
                 back: "gst-pipeline: droidcamsrc mode=2 camera-device=" + camera.deviceId + " ! video/x-raw ! videoconvert ! qtvideosink",
                 backRecord:
-                    "gst-pipeline: droidcamsrc camera-device=" + camera.deviceId + " mode=2 ! tee name=t " +
-                    "t. ! queue ! video/x-raw, width=" +
-                    (camera.viewfinder.resolution.width * 3 / 4) + ", height=" +
-                    (camera.viewfinder.resolution.height * 3 / 4) + " ! videoconvert ! qtvideosink " +
-
-                    "t. ! queue ! video/x-raw, width=" +
-                    (camera.viewfinder.resolution.width * 3 / 4) +
-                    ", height=" +
-                    (camera.viewfinder.resolution.height * 3 / 4) +
-                    " ! videoconvert ! videoflip video-direction=" +
-                    cameraItem.lockedVideoRotation +
-                    " ! jpegenc ! mkv. " +
-
-                    "autoaudiosrc ! queue ! audioconvert ! droidaenc ! mkv. " +
-                    "matroskamux name=mkv ! filesink location=" + outputPath
+                    "gst-pipeline: droidcamsrc camera-device="
+                    + camera.deviceId + " mode=2 ! tee name=t "
+                    + "t. ! queue ! video/x-raw, width="
+                    + vidW
+                    + ", height="
+                    + vidH
+                    + " ! videoconvert ! qtvideosink "
+                    + "t. ! queue ! video/x-raw, width="
+                    + vidW
+                    + ", height="
+                    + vidH
+                    + " ! videoconvert ! videoflip video-direction="
+                    + cameraItem.lockedVideoRotation
+                    + " ! "
+                    + videoEncoder
+                    + " ! mkv. autoaudiosrc ! queue ! audioconvert ! droidaenc"
+                    + " ! mkv. matroskamux name=mkv ! filesink location="
+                    + outputPath
             }
         ]
 


### PR DESCRIPTION
Replace jpegenc (Motion JPEG) MJPEG encoded every frame as a full JPEG to h264 an actual video encoder

Originally taken from nico359 from his downstream camera fork. I was considering using opus but not sure its worth the cpu encoding vs the hw accelerated droidaenc

Also fixed what looked like a typo of camera_device instead of camera-device

Before
```
Stream #0:0(eng): Video: mjpeg (Baseline) (MJPG / 0x47504A4D), yuvj420p(pc, bt470bg/bt709/bt709, progressive), 1080x1440 [SAR 1:1 DAR 3:4], 30 fps, 30 tbr, 1k tbn, start 0.692000 (default)
    Metadata:
      title           : Video
  Stream #0:1(eng): Audio: aac (LC), 44100 Hz, stereo, fltp (default)
    Metadata:
      title           : Audio
```
after
```
  Stream #0:0(eng): Video: h264 (Constrained Baseline), yuv420p(tv, bt709, progressive), 1440x1080 [SAR 1:1 DAR 4:3], 30 fps, 30 tbr, 1k tbn, start 1.011000 (default)
    Metadata:
      title           : Video
  Stream #0:1(eng): Audio: aac (LC), 44100 Hz, stereo, fltp (default)
    Metadata:
      title           : Audio
```